### PR TITLE
fix layer so that it only ever draws once, which is all it needs to draw

### DIFF
--- a/UC2013_TipsAndTricksDemos/CustomDynamicLayer/CustomDynamicLayer/CustomDynamicLayer.m
+++ b/UC2013_TipsAndTricksDemos/CustomDynamicLayer/CustomDynamicLayer/CustomDynamicLayer.m
@@ -58,7 +58,7 @@
     
     // only draw if the requested envelope intersects the envelope of the
     // georeferenced image
-    if (![env intersectionWithEnvelope:self.fullEnvelope]){
+    if (![env intersectsWithEnvelope:self.fullEnvelope]){
         return;
     }
     


### PR DESCRIPTION
Fix layer so that it only ever draws once, which is all it needs to draw, this greatly helps performance.
Add some defensive code for if the layer is added to a different map at some point.
Add defensive code for making sure the spatial reference matches.
